### PR TITLE
✨ iframe friendly mode and fix of no-template bug in CI codes

### DIFF
--- a/functions/modules/events.js
+++ b/functions/modules/events.js
@@ -112,6 +112,8 @@ async function get_event_template_by_code( an_event_qr_hash ) {
 
 	try {
 
+		if( an_event_qr_hash.includes( 'testing'  ) ) return {}
+
 		// Get event ID as known within the POAP system
 		const { event } = await call_poap_endpoint( `/actions/claim-qr`, { qr_hash: an_event_qr_hash } )
 		const { event_template_id } = event
@@ -136,7 +138,7 @@ async function get_event_template_by_code( an_event_qr_hash ) {
 exports.get_event_template_by_code = get_event_template_by_code
 
 exports.registerEvent = async function( data, context ) {
-	
+
 	try {
 
 		// Add a week grace period in case we need to debug anything

--- a/src/components/atoms/QR.js
+++ b/src/components/atoms/QR.js
@@ -15,7 +15,7 @@ const glow = color => keyframes`
 
 
 export default styled( QRCode )`
-	margin: 2rem 0;
+	margin: ${ ( { margin='2rem 0' } ) => margin };
 	opacity: 1;
 	&.glow {
 		animation: ${ ( { theme } ) => glow( theme.colors.primary  )} 1.5s ease-in-out 1;

--- a/src/components/organisms/EventView.js
+++ b/src/components/organisms/EventView.js
@@ -46,10 +46,20 @@ export default function ViewQR( ) {
 	const [ internalEventId, setInternalEventId ] = useState( eventId || stateEventId )
   const [ scanInterval, setScanInterval ] = useState( defaultScanInerval )
   const [ acceptedTerms, setAcceptedTerms ] = useState( viewMode == 'silent' )
+  const [ iframeMode, setIframeMode ] = useState( false )
 
   // ///////////////////////////////
   // Lifecycle handling
   // ///////////////////////////////
+
+  // Mode handling
+  useEffect( f => {
+
+    if( !viewMode ) return
+    if( viewMode == 'silent' ) setAcceptedTerms( true )
+    if( viewMode == 'iframe' ) setIframeMode( true )
+
+  }, [ viewMode  ] )
 
   // Health check
   useEffect( (  ) => {
@@ -152,7 +162,7 @@ export default function ViewQR( ) {
     refreshScannedCodesStatuses( internalEventId )
     .then( ( { data } ) => log( `Remote code update response : `, data ) )
     .catch( e => log( `Code refresh error `, e ) )
-    
+
   }, scanInterval )
 
   // Debugging helper
@@ -167,9 +177,12 @@ export default function ViewQR( ) {
   // Render component
   // ///////////////////////////////
 
+  // If iframe mode, render only QR
+  if( iframeMode ) return <QR key={ internalEventId + event?.public_auth?.token } margin='0' data-code={ `${ internalEventId }/${ event?.public_auth?.token }` } value={ `${ REACT_APP_publicUrl }/claim/${ internalEventId }/${ event?.public_auth?.token }${ force_appcheck_fail ? '?FORCE_INVALID_APPCHECK=true' : '' }` } />
+
   // Show welcome screen
   if( !acceptedTerms ) return <Container>
-    
+
     <H1 align="center">Before we begin</H1>
 
     <H2>Keep your internet on</H2>
@@ -184,20 +197,20 @@ export default function ViewQR( ) {
 
   // Expired event error
   if( event?.expires && event.expires < Date.now() ) return <Container>
-  
+
     <h1>QR Kiosk expired</h1>
     <Sidenote>This kiosk was set to expire on { new Date( event.expires ).toString(  ) } by the organiser.</Sidenote>
-    
+
   </Container>
 
   // No code error
   if( !event?.public_auth?.expires ) return <Container>
-  
+
     <h1>No codes available</h1>
     <Sidenote onClick={ f => navigate( '/admin' ) }>If you just uploaded new ones, give the backend a minute to catch up. If nothing happens for a while, click here to open the admin interface.</Sidenote>
-    
+
   </Container>
-  
+
   // Display QR
   log( template )
   return <Container background={ template?.footer_icon }>

--- a/src/components/organisms/EventView.js
+++ b/src/components/organisms/EventView.js
@@ -212,7 +212,6 @@ export default function ViewQR( ) {
   </Container>
 
   // Display QR
-  log( template )
   return <Container background={ template?.footer_icon }>
 
     {  /* Event metadata */ }


### PR DESCRIPTION
Iframe-friendly mode allows for `http://localhost:3000/#/event/event_id/iframe` url parameter, which will only display the QR in `265x256`px.

Found a small bug where `testing-*` codes would cause an error in the template fetching.