### PR TITLE
🐛 fix faulty reference to non-annotated QR

### DIFF
--- a/src/components/organisms/EventView.js
+++ b/src/components/organisms/EventView.js
@@ -185,7 +185,7 @@ export default function ViewQR( ) {
   // ///////////////////////////////
 
   // If iframe mode, render only QR
-  if( iframeMode ) return <QR key={ internalEventId + event?.public_auth?.token } margin='0' data-code={ `${ internalEventId }/${ event?.public_auth?.token }` } value={ `${ REACT_APP_publicUrl }/claim/${ internalEventId }/${ event?.public_auth?.token }${ force_appcheck_fail ? '?FORCE_INVALID_APPCHECK=true' : '' }` } />
+  if( iframeMode ) return <AnnotatedQR key={ internalEventId + event?.public_auth?.token } margin='0' data-code={ `${ internalEventId }/${ event?.public_auth?.token }` } value={ `${ REACT_APP_publicUrl }/claim/${ internalEventId }/${ event?.public_auth?.token }${ force_appcheck_fail ? '?FORCE_INVALID_APPCHECK=true' : '' }` } />
 
   // Show welcome screen
   if( !acceptedTerms ) return <Container>


### PR DESCRIPTION
The faulty QR reference you mentioned @arvee-init was caught by eslint and broke the previous merge. This should fix that.