### PR TITLE
🐛 do more strict check on code claim status and not just on validity

### DIFF
--- a/functions/modules/codes.js
+++ b/functions/modules/codes.js
@@ -453,11 +453,11 @@ exports.get_code_by_challenge = async ( data, context ) => {
 				claimed: oldestCode.uid.includes( 'testing' ) ? true : 'unknown'
 			}, { merge: true } )
 
-			// Check whether the code is actuallt valid
-			const is_available = await checkCodeStatus( oldestCode.uid )
+			// Check whether the code is actually valid
+			const code_meta = await checkCodeStatus( oldestCode.uid )
 
 			// If this code is confirmed available, send it to the user
-			if( is_available ) valid_code = oldestCode
+			if( code_meta && !code_meta?.claimed ) valid_code = oldestCode
 
 		}
 


### PR DESCRIPTION
Santi's "code already claimed" error stemmed from the current process only checking if a code exists and is valid, not whether it has been claimed. This should remedy that.